### PR TITLE
Moved most of processing to project.afterEvaluate

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=io.github.jonloucks.gradle.kit
-version=0.4.1
+version=0.5.0

--- a/src/main/java/io/github/jonloucks/gradle/kit/JacocoApplier.java
+++ b/src/main/java/io/github/jonloucks/gradle/kit/JacocoApplier.java
@@ -1,6 +1,7 @@
 package io.github.jonloucks.gradle.kit;
 
 import org.gradle.api.Action;
+import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.tasks.SourceSet;
@@ -25,8 +26,10 @@ final class JacocoApplier {
         log("Applying jacoco plugin...");
         targetProject.getPlugins().apply("jacoco");
         
-        configureJacocoPlugin();
-        configureExistingReports();
+        targetProject.afterEvaluate(project -> {
+            configureJacocoPlugin();
+            configureExistingReports();
+        });
     }
     
     private void configureExistingReports() {

--- a/src/main/java/io/github/jonloucks/gradle/kit/JavaLibraryPlugin.java
+++ b/src/main/java/io/github/jonloucks/gradle/kit/JavaLibraryPlugin.java
@@ -28,9 +28,11 @@ public final class JavaLibraryPlugin implements Plugin<@NotNull Project> {
         
         private void apply() {
             applyJavaLibraryPlugin();
-            new JavaVersioningApplier(project).apply();
-            new JacocoApplier(project).apply();
-            new JavadocApplier(project).apply();
+            project.afterEvaluate(x -> {
+                new JavaVersioningApplier(project).apply();
+                new JacocoApplier(project).apply();
+                new JavadocApplier(project).apply();
+            });
         }
         
         private void applyJavaLibraryPlugin() {

--- a/src/main/java/io/github/jonloucks/gradle/kit/JavaVersioningApplier.java
+++ b/src/main/java/io/github/jonloucks/gradle/kit/JavaVersioningApplier.java
@@ -26,12 +26,15 @@ final class JavaVersioningApplier {
     }
     
     void apply() {
-        configureJavaVersions();
-        configureTestTaggingRules();
+        log("Applying Java versions ...");
+        
+        targetProject.afterEvaluate(x -> {
+            configureJavaVersions();
+            configureTestTaggingRules();
+        });
     }
     
     private void configureJavaVersions() {
-        log("Applying Java versions ...");
         configureJavaPlugin();
         configureAllJavaCompiles();
     }

--- a/src/main/java/io/github/jonloucks/gradle/kit/JavadocApplier.java
+++ b/src/main/java/io/github/jonloucks/gradle/kit/JavadocApplier.java
@@ -1,5 +1,6 @@
 package io.github.jonloucks.gradle.kit;
 
+import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 import org.gradle.api.tasks.javadoc.Javadoc;
 import org.gradle.external.javadoc.MinimalJavadocOptions;
@@ -13,12 +14,15 @@ final class JavadocApplier {
     
     void apply() {
         log("Applying javadoc...");
-
-        targetProject.getTasks().withType(Javadoc.class).configureEach( javadoc -> {
-            javadoc.setFailOnError(true);
-            javadoc.getModularity().getInferModulePath().set(true);
-            javadoc.options(MinimalJavadocOptions::showFromPublic);
+        
+        targetProject.afterEvaluate(project -> {
+            targetProject.getTasks().withType(Javadoc.class).configureEach( javadoc -> {
+                javadoc.setFailOnError(true);
+                javadoc.getModularity().getInferModulePath().set(true);
+                javadoc.options(MinimalJavadocOptions::showFromPublic);
+            });
         });
+ 
     }
 
     private final Project targetProject;

--- a/src/main/java/io/github/jonloucks/gradle/kit/MavenPublishPlugin.java
+++ b/src/main/java/io/github/jonloucks/gradle/kit/MavenPublishPlugin.java
@@ -42,13 +42,16 @@ public final class MavenPublishPlugin implements Plugin<@NotNull Project> {
         private void apply() {
             applyMavenPublishPlugin();
             
-            if (isRootProject(project)) {
-                registerCreatePublisherBundle();
-                registerUploadPublisherBundle();
-            }
-            
-            createStagingRepository();
-            configureChecksums();
+            project.afterEvaluate(x -> {
+                if (isRootProject(project)) {
+                    registerCreatePublisherBundle();
+                    registerUploadPublisherBundle();
+                }
+                
+                createStagingRepository();
+                configureChecksums();
+            });
+
         }
         
         private void configureChecksums() {

--- a/src/main/java/io/github/jonloucks/gradle/kit/SigningPlugin.java
+++ b/src/main/java/io/github/jonloucks/gradle/kit/SigningPlugin.java
@@ -35,7 +35,9 @@ public final class SigningPlugin implements Plugin<@NotNull Project> {
         
         private void apply() {
             applySigningPlugin();
-            configureSigning();
+            project.afterEvaluate(x -> {
+                configureSigning();
+            });
         }
         
         private void configureSigning() {

--- a/src/test/java/io/github/jonloucks/gradle/kit/test/JavaLibraryPluginTest.java
+++ b/src/test/java/io/github/jonloucks/gradle/kit/test/JavaLibraryPluginTest.java
@@ -26,6 +26,7 @@ public final class JavaLibraryPluginTest {
     public void plugin_JavaAndJdkVersions() {
         final Project project = ProjectBuilder.builder().build();
         project.getPlugins().apply(JAVA_LIBRARY_KIT);
+        project.evaluationDependsOn(":");
         
         final JavaPluginExtension javaPlugin = project.getExtensions().getByType(JavaPluginExtension.class);
         
@@ -43,6 +44,7 @@ public final class JavaLibraryPluginTest {
     public void plugin_TestTagging() {
         final Project project = ProjectBuilder.builder().build();
         project.getPlugins().apply(JAVA_LIBRARY_KIT);
+        project.evaluationDependsOn(":");
         
         assertDoesNotThrow(()-> {
             project.getTasks().named("integrationTest");

--- a/src/test/java/io/github/jonloucks/gradle/kit/test/JavaPluginTest.java
+++ b/src/test/java/io/github/jonloucks/gradle/kit/test/JavaPluginTest.java
@@ -25,7 +25,8 @@ public final class JavaPluginTest {
     public void plugin_JavaAndJdkVersions() {
         final Project project = ProjectBuilder.builder().build();
         project.getPlugins().apply(JAVA_KIT);
-
+        project.evaluationDependsOn(":");
+        
         final JavaPluginExtension javaPlugin = project.getExtensions().getByType(JavaPluginExtension.class);
 
         assertThat(javaPlugin.getSourceCompatibility(), equalTo(JavaVersion.toVersion(SOURCE_VERSION)));


### PR DESCRIPTION
Moving code to afterEvaluate everything is initialized.
Some difficulties during development were related to trying to configure projects too early.